### PR TITLE
fix: add daps.secret.clientId and daps.secret.clientSecret

### DIFF
--- a/charts/omejdn-server/values.yaml
+++ b/charts/omejdn-server/values.yaml
@@ -123,3 +123,8 @@ tolerations: []
 
 # -- Pod affinity configuration
 affinity: {}
+
+daps:
+  secret:
+    clientId: ""
+    clientSecret: ""


### PR DESCRIPTION
values-beta.yaml contains these keys, so the base values.yaml has to have them too empty string is ok in this one, environment specific values files can override their values